### PR TITLE
Re: Fix type exports

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,2 +1,3 @@
 import { InertiaDrag } from './InertiaDrag';
+export { InertiaMoveEvent, DragStartEvent, DragMoveEvent, DragEndEvent, DragCancelEvent } from './InertiaDrag';
 export default InertiaDrag;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 import { InertiaDrag } from './InertiaDrag';
+export { InertiaMoveEvent, DragStartEvent, DragMoveEvent, DragEndEvent, DragCancelEvent } from './InertiaDrag';
 export default InertiaDrag;


### PR DESCRIPTION
Sorry to bother you again. 😓 

We need to re-export types from `index.ts` manually.